### PR TITLE
Set-GitHubRepoVulnerabilitySetting: Added enabling of secret scanning

### DIFF
--- a/src/GitHubRepoManager/Functions/Public/Set-GitHubRepoVulnerabilitySetting.ps1
+++ b/src/GitHubRepoManager/Functions/Public/Set-GitHubRepoVulnerabilitySetting.ps1
@@ -49,6 +49,14 @@ function Set-GitHubRepoVulnerabilitySetting {
         if ($ExcludedRepoPrefix) {
             Write-Host "with excluded prefix $ExcludedRepoPrefix"
         }
+        $EnableSecretScanningBodyParams = @{
+            security_and_analysis = @{
+                secret_scanning = @{
+                    status = "enabled"
+                }
+            }
+        }
+        $EnableSecretScanningBodyParamsJson = $EnableSecretScanningBodyParams | ConvertTo-Json
         foreach ($Repo in $Repos) {
             $Uri = "/repos/$GitHubOrg/$($Repo.name)/vulnerability-alerts"
             if ($PSCmdlet.ShouldProcess($Repo.name)) {
@@ -59,6 +67,11 @@ function Set-GitHubRepoVulnerabilitySetting {
             if ($PSCmdlet.ShouldProcess($Repo.name)) {
                 Write-Host "Enabling automated security fixes for $($Repo.name)"
                 Invoke-GitHubRestMethod -Method PUT -Uri $Uri
+            }
+            $Uri = "/repos/$GitHubOrg/$($Repo.name)"
+            if ($PSCmdlet.ShouldProcess($Repo.name)) {
+                Write-Host "Enabling secret scanning for $($Repo.name)"
+                Invoke-GitHubRestMethod -Method PATCH -Uri $Uri -Body $EnableSecretScanningBodyParamsJson
             }
         }
     }

--- a/tests/UT.Set-GitHubRepoVulnerabilitySetting.Tests.ps1
+++ b/tests/UT.Set-GitHubRepoVulnerabilitySetting.Tests.ps1
@@ -19,10 +19,10 @@ Describe "Set-GitHubRepoVulnerabilitySetting tests" -Tags @("Unit") {
         return $null
     }
     Context "All mandatory parameters are passed" {
-        It "Should not throw and 4 calls of Invoke-GitHubRestMethod for the two repositories" {
+        It "Should not throw and 6 calls of Invoke-GitHubRestMethod for the two repositories" {
             Set-GitHubSessionInformation -PatToken "not-a-real-pat-token"
             { Set-GitHubRepoVulnerabilitySetting -GitHubOrg "FooBarAgency" -RepoPrefix "foo-" } | Should not throw
-            Assert-MockCalled -CommandName Invoke-GitHubRestMethod -ModuleName GitHubToolKit -Times 4 -Exactly
+            Assert-MockCalled -CommandName Invoke-GitHubRestMethod -ModuleName GitHubToolKit -Times 6 -Exactly
         }
     }
     Context "All mandatory parameters and optional ExcludedRepoPrefix parameter passed" {


### PR DESCRIPTION
Added enabling of secret scanning to Set-GitHubRepoVulnerabilitySetting

Docs:
https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#update-a-repository
https://docs.github.com/en/code-security/secret-scanning/about-secret-scanning