### PR TITLE
Enable secret scanning on only public repos

### DIFF
--- a/src/GitHubRepoManager/Functions/Public/Set-GitHubRepoVulnerabilitySetting.ps1
+++ b/src/GitHubRepoManager/Functions/Public/Set-GitHubRepoVulnerabilitySetting.ps1
@@ -69,7 +69,7 @@ function Set-GitHubRepoVulnerabilitySetting {
                 Invoke-GitHubRestMethod -Method PUT -Uri $Uri
             }
             $Uri = "/repos/$GitHubOrg/$($Repo.name)"
-            if ($PSCmdlet.ShouldProcess($Repo.name)) {
+            if ($PSCmdlet.ShouldProcess($Repo.name) -and !$Repo.isPrivate) {
                 Write-Host "Enabling secret scanning for $($Repo.name)"
                 Invoke-GitHubRestMethod -Method PATCH -Uri $Uri -Body $EnableSecretScanningBodyParamsJson
             }

--- a/tests/UT.Set-GitHubRepoVulnerabilitySetting.Tests.ps1
+++ b/tests/UT.Set-GitHubRepoVulnerabilitySetting.Tests.ps1
@@ -19,10 +19,10 @@ Describe "Set-GitHubRepoVulnerabilitySetting tests" -Tags @("Unit") {
         return $null
     }
     Context "All mandatory parameters are passed" {
-        It "Should not throw and 6 calls of Invoke-GitHubRestMethod for the two repositories" {
+        It "Should not throw and 4 calls of Invoke-GitHubRestMethod for the two repositories" {
             Set-GitHubSessionInformation -PatToken "not-a-real-pat-token"
             { Set-GitHubRepoVulnerabilitySetting -GitHubOrg "FooBarAgency" -RepoPrefix "foo-" } | Should not throw
-            Assert-MockCalled -CommandName Invoke-GitHubRestMethod -ModuleName GitHubToolKit -Times 6 -Exactly
+            Assert-MockCalled -CommandName Invoke-GitHubRestMethod -ModuleName GitHubToolKit -Times 4 -Exactly
         }
     }
     Context "All mandatory parameters and optional ExcludedRepoPrefix parameter passed" {


### PR DESCRIPTION
Correction following https://github.com/SkillsFundingAgency/das-github-toolkit/pull/19

Secret scanning can only be enabled on public repositories